### PR TITLE
Recompile files whose output has been modified since last compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ Usage: parallel-transpile [options] -o outputDirectory inputDirectory
   -o, --output        the output directory
   -p, --parallel      how many instances to run in parallel
                         (defaults to number of CPUs)
+  -m, --maxParallel   maximum number of instances to run in parallel
+                        (defaults to 16)
   -t, --type          add a type to be converted, see below
                         (can be called multiple times)
   -n, --newer         only build files newer than destination files
+  -d, --delete        delete files that no longer have a source
+  -x, --paranoid      don't trust compiled code to be unmodified
 
 Types
 

--- a/cli.js
+++ b/cli.js
@@ -12,7 +12,7 @@ error = function(message) {
 };
 
 usage = function() {
-  return console.log("Usage: parallel-transpile [options] -o outputDirectory inputDirectory\n\n  -h, --help          display this help message\n  -v, --version       output version number\n  -w, --watch         watch input directories for changes\n  -o, --output        the output directory\n  -p, --parallel      how many instances to run in parallel\n                        (defaults to number of CPUs)\n  -m, --maxParallel   maximum number of instances to run in parallel\n                        (defaults to 16)\n  -t, --type          add a type to be converted, see below\n                        (can be called multiple times)\n  -n, --newer         only build files newer than destination files\n  -d, --delete        delete files that no longer have a source\n\nTypes\n\n  Each type takes an input filter (file extension), a list of loaders, and\n  an output extension. To copy a file verbatim, only the input filter is\n  required.\n\n  For example, to copy all JSON files verbatim:\n\n    -t \".json\"\n\n  To compile a CJSX file to JavaScript:\n\n    -t \".cjsx:coffee-loader,cjsx-loader:.js\"\n\n  Loaders operate from right to left, like in webpack.");
+  return console.log("Usage: parallel-transpile [options] -o outputDirectory inputDirectory\n\n  -h, --help          display this help message\n  -v, --version       output version number\n  -w, --watch         watch input directories for changes\n  -o, --output        the output directory\n  -p, --parallel      how many instances to run in parallel\n                        (defaults to number of CPUs)\n  -m, --maxParallel   maximum number of instances to run in parallel\n                        (defaults to 16)\n  -t, --type          add a type to be converted, see below\n                        (can be called multiple times)\n  -n, --newer         only build files newer than destination files\n  -d, --delete        delete files that no longer have a source\n  -x, --paranoid      don't trust compiled code to be unmodified\n\nTypes\n\n  Each type takes an input filter (file extension), a list of loaders, and\n  an output extension. To copy a file verbatim, only the input filter is\n  required.\n\n  For example, to copy all JSON files verbatim:\n\n    -t \".json\"\n\n  To compile a CJSX file to JavaScript:\n\n    -t \".cjsx:coffee-loader,cjsx-loader:.js\"\n\n  Loaders operate from right to left, like in webpack.");
 };
 
 minimistOptions = {
@@ -25,10 +25,11 @@ minimistOptions = {
     "w": "watch",
     "t": "type",
     "n": "newer",
-    "d": "delete"
+    "d": "delete",
+    "x": "paranoid"
   },
   string: ["output", "parallel", "maxParallel", "type"],
-  boolean: ["watch", "newer", "delete"],
+  boolean: ["watch", "newer", "delete", "paranoid"],
   multiple: ["type"],
   unknown: function(o) {
     if (o.slice(0, 1) === "-") {

--- a/index.js
+++ b/index.js
@@ -575,7 +575,6 @@ module.exports = function(options, callback) {
           return done();
         }
         return Checksum.file(filename, function(err, csum) {
-          debug("Checking output " + filename);
           if (csum === obj.outputChecksum) {
             return done();
           } else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parallel-transpile",
-  "version": "0.6.0",
+  "version": "0.6.1-rc1",
   "description": "Transpile files in parallel using all available CPUs",
   "main": "index.js",
   "bin": {

--- a/src/cli.coffee
+++ b/src/cli.coffee
@@ -21,6 +21,7 @@ usage = ->
                             (can be called multiple times)
       -n, --newer         only build files newer than destination files
       -d, --delete        delete files that no longer have a source
+      -x, --paranoid      don't trust compiled code to be unmodified
 
     Types
 
@@ -50,6 +51,7 @@ minimistOptions =
     "t": "type"
     "n": "newer"
     "d": "delete"
+    "x": "paranoid"
 
   string: [
     "output"
@@ -62,6 +64,7 @@ minimistOptions =
     "watch"
     "newer"
     "delete"
+    "paranoid"
   ]
 
   multiple: [

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -364,7 +364,6 @@ module.exports = (options, callback) ->
         if !options.paranoid
           return done()
         Checksum.file filename, (err, csum) ->
-          debug("Checking output #{filename}")
           if csum is obj.outputChecksum
             return done()
           else

--- a/src/worker.coffee
+++ b/src/worker.coffee
@@ -78,6 +78,7 @@ process.on 'message', (m) ->
           """
       fs.writeFileSync(outPath, src)
       fs.writeFileSync(mapPath, sourceMapString) if sourceMapString
+      details.outputChecksum = Checksum(src)
       send {msg: 'complete', details: details}
 
     absoluteOutPath = Path.resolve(outPath)

--- a/test/scss-newer-test.coffee
+++ b/test/scss-newer-test.coffee
@@ -48,7 +48,7 @@ describe 'SCSS newer', ->
         color: #0f0; }
       """
 
-  it 'then modifies bar.css', ->
+  it 'then modifies bar.scss', ->
     @fooMtime = getFileStats("scss/foo.css").mtime
     @barMtime = getFileStats("scss/bar.css").mtime
     fs.writeFileSync "#{SCRATCHPAD_SOURCE}/scss/bar.scss",
@@ -76,7 +76,7 @@ describe 'SCSS newer', ->
         background-color: #0f0; }
       """
 
-  it 'then modifies _vars.css', ->
+  it 'then modifies _vars.scss', ->
     @fooMtime = getFileStats("scss/foo.css").mtime
     @barMtime = getFileStats("scss/bar.css").mtime
     fs.writeFileSync "#{SCRATCHPAD}/lib/scss/_vars.scss",
@@ -127,7 +127,7 @@ describe 'SCSS newer', ->
   it 'still remembers foo.css', ->
     expect(getState().files).to.contain.all.keys("#{SCRATCHPAD_OUTPUT}/scss/foo.css")
 
-  it 'then restores bar.css', ->
+  it 'then restores bar.scss', ->
     @fooMtime = getFileStats("scss/foo.css").mtime
     fs.writeFileSync "#{SCRATCHPAD_SOURCE}/scss/bar.scss",
       """
@@ -183,4 +183,3 @@ describe 'SCSS newer', ->
       .bar {
         background-color: green; }
       """
-

--- a/test/scss-paranoid-test.coffee
+++ b/test/scss-paranoid-test.coffee
@@ -1,0 +1,89 @@
+{
+  SCRATCHPAD
+  SCRATCHPAD_SOURCE
+  SCRATCHPAD_OUTPUT
+  expect
+  parallelTranspile
+  setupScratchpad
+  transpile
+  setupTranspiler
+  teardownTranspiler
+  transpileWait
+  getOutput
+  getState
+  getFileStats
+} = require './test_helper'
+fs = require 'fs'
+
+scssOptions =
+  includePaths: ["#{SCRATCHPAD}/lib/scss"]
+  indentedSyntax: false
+
+RULES =
+  scss:
+    inExt: ".scss"
+    loaders: ["sass-loader?#{JSON.stringify(scssOptions)}"]
+    outExt: ".css"
+
+describe 'SCSS paranoid', ->
+
+  before setupScratchpad
+
+  before transpile
+    delete: true
+    newer: true
+    rules: [
+      RULES.scss
+    ]
+
+  it 'compiles foo.css', ->
+    expect(getOutput("scss/foo.css", 'utf-8')).to.eql """
+      .foo {
+        color: #f00; }
+      """
+
+  it 'compiles bar.css', ->
+    expect(getOutput("scss/bar.css", 'utf-8')).to.eql """
+      .bar {
+        color: #0f0; }
+      """
+
+  it 'then we modify *compiled* file bar.css', ->
+    @fooMtime = getFileStats("scss/foo.css").mtime
+    @barMtime = getFileStats("scss/bar.css").mtime
+    fs.writeFileSync "#{SCRATCHPAD_OUTPUT}/scss/bar.css", """
+      .bar{}
+      """
+
+  it 'then we compile again', transpile
+    delete: true
+    newer: true
+    rules: [
+      RULES.scss
+    ]
+
+
+  it 'foo.css should be unchanged', ->
+    expect(getFileStats("scss/foo.css").mtime).to.eql @fooMtime
+
+  it 'bar.css should be unchanged', ->
+    expect(getOutput("scss/bar.css", 'utf-8')).to.eql """
+      .bar{}
+      """
+
+  it 'then we compile again, paranoid', transpile
+    delete: true
+    newer: true
+    paranoid: true
+    rules: [
+      RULES.scss
+    ]
+
+  it 'foo.css should be unchanged', ->
+    expect(getFileStats("scss/foo.css").mtime).to.eql @fooMtime
+
+  it 'compiles bar.css', ->
+    expect(getOutput("scss/bar.css", 'utf-8')).to.eql """
+      .bar {
+        color: #0f0; }
+      """

--- a/worker.js
+++ b/worker.js
@@ -104,6 +104,7 @@ process.on('message', function(m) {
       if (sourceMapString) {
         fs.writeFileSync(mapPath, sourceMapString);
       }
+      details.outputChecksum = Checksum(src);
       return send({
         msg: 'complete',
         details: details


### PR DESCRIPTION
Our build system has an issue wherein to version the files it modifies the files that `parallel-transpile` has compiled in order to reference the new, versioned, filenames.

For example if `foo.jsx` references `image.jpg` and we version `image.jpg` -> `image.13371337.jpg`; it will modify the *compiled* `foo.js` to reference `image.13371337.jpg` instead.

This is fine; but the next time we compile with a new `image.jpg` (-> `image.00bada55.jpg`) if `foo.jsx` has not been modified then it is not recompiled. The versioning system skips over the compiled `foo.js` because it doesn't match `image.jpg` any more, and the stale `image.13371337.jpg` reference is maintained.

This PR adds a `paranoid` mode to `parallel-transpile` where it no longer trusts the compiled code to be unmodified - it checks it with a checksum. If it has been modified, the file will be recompiled regardless.

This does not affect watch mode.